### PR TITLE
lib: add Txid and Outpoint

### DIFF
--- a/src/bitcoin.udl
+++ b/src/bitcoin.udl
@@ -36,6 +36,14 @@ interface FeeRate {
   u64 to_sat_per_kwu();
 };
 
+[Custom]
+typedef string Txid;
+
+dictionary OutPoint {
+  Txid txid;
+  u32 vout;
+};
+
 [NonExhaustive]
 enum Network {
   "Bitcoin",

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-pub use bitcoin::amount::ParseAmountError as BitcoinParseAmountError;
+use bitcoin::amount::ParseAmountError as BitcoinParseAmountError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum FeeRateError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 use bitcoin::Amount as BitcoinAmount;
 use bitcoin::FeeRate as BitcoinFeeRate;
 use bitcoin::ScriptBuf as BitcoinScriptBuf;
+pub use bitcoin::OutPoint;
+pub use bitcoin::Txid;
 
 use error::FeeRateError;
 use error::ParseAmountError;
@@ -67,8 +69,8 @@ impl Amount {
     }
 
     pub fn from_btc(btc: f64) -> Result<Self, ParseAmountError> {
-        let bdk_amount = BitcoinAmount::from_btc(btc).map_err(ParseAmountError::from)?;
-        Ok(Amount(bdk_amount))
+        let bitcoin_amount = BitcoinAmount::from_btc(btc).map_err(ParseAmountError::from)?;
+        Ok(Amount(bitcoin_amount))
     }
 
     pub fn to_sat(&self) -> u64 {
@@ -82,5 +84,16 @@ impl Amount {
 
 impl_from_core_type!(Amount, BitcoinAmount);
 impl_from_ffi_type!(Amount, BitcoinAmount);
+
+impl UniffiCustomTypeConverter for Txid {
+    type Builtin = String;
+    fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
+        Ok(val.parse::<Txid>()?)
+    }
+
+    fn from_custom(obj: Self) -> Self::Builtin {
+        obj.to_string()
+    }
+}
 
 uniffi::include_scaffolding!("bitcoin");


### PR DESCRIPTION
I deviated a little from the `bdk-ffi` approach as I think other projects can make use of `Txid` without an `Outpoint`. 

Edit: took this a much simpler direction in response to comments on a trait from UniFFI I was unaware of. 