### PR TITLE
feat: add address type

### DIFF
--- a/src/bitcoin.udl
+++ b/src/bitcoin.udl
@@ -52,9 +52,46 @@ enum Network {
   "Regtest",
 };
 
+[Traits=(Display)]
+interface Address {
+  [Throws=AddressParseError]
+  constructor(string address, Network network);
+
+  [Name=from_script, Throws=FromScriptError]
+  constructor(Script script, Network network);
+
+  Script script_pubkey();
+
+  string to_qr_uri();
+
+  boolean is_valid_for_network(Network network);
+};
+
 // ------------------------------------------------------------------------
 // Errors
 // ------------------------------------------------------------------------
+
+[Error]
+enum AddressParseError {
+    "Base58",
+    "Bech32",
+    "WitnessVersion",
+    "WitnessProgram",
+    "UnknownHrp",
+    "LegacyAddressTooLong",
+    "InvalidBase58PayloadLength",
+    "InvalidLegacyPrefix",
+    "NetworkValidation",
+    "OtherAddressParseErr",
+};
+
+[Error]
+interface FromScriptError {
+  UnrecognizedScript();
+  WitnessProgram(string error_message);
+  WitnessVersion(string error_message);
+  OtherFromScriptErr();
+};
 
 [Error]
 interface ParseAmountError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,89 @@
+pub use bitcoin::address::FromScriptError as BitcoinFromScriptError;
+pub use bitcoin::address::ParseError as BitcoinParseError;
 use bitcoin::amount::ParseAmountError as BitcoinParseAmountError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum AddressParseError {
+    #[error("base58 address encoding error")]
+    Base58,
+    #[error("bech32 address encoding error")]
+    Bech32,
+    #[error("witness version conversion/parsing error: {error_message}")]
+    WitnessVersion { error_message: String },
+    #[error("witness program error: {error_message}")]
+    WitnessProgram { error_message: String },
+    #[error("tried to parse an unknown hrp")]
+    UnknownHrp,
+    #[error("legacy address base58 string")]
+    LegacyAddressTooLong,
+    #[error("legacy address base58 data")]
+    InvalidBase58PayloadLength,
+    #[error("segwit address bech32 string")]
+    InvalidLegacyPrefix,
+    #[error("validation error")]
+    NetworkValidation,
+    #[error("other address parse error")]
+    OtherAddressParseErr,
+}
+
+impl From<BitcoinParseError> for AddressParseError {
+    fn from(error: BitcoinParseError) -> Self {
+        match error {
+            BitcoinParseError::Base58(_) => AddressParseError::Base58,
+            BitcoinParseError::Bech32(_) => AddressParseError::Bech32,
+            BitcoinParseError::WitnessVersion(e) => AddressParseError::WitnessVersion {
+                error_message: e.to_string(),
+            },
+            BitcoinParseError::WitnessProgram(e) => AddressParseError::WitnessProgram {
+                error_message: e.to_string(),
+            },
+            BitcoinParseError::UnknownHrp(_) => AddressParseError::UnknownHrp,
+            BitcoinParseError::LegacyAddressTooLong(_) => AddressParseError::LegacyAddressTooLong,
+            BitcoinParseError::InvalidBase58PayloadLength(_) => {
+                AddressParseError::InvalidBase58PayloadLength
+            }
+            BitcoinParseError::InvalidLegacyPrefix(_) => AddressParseError::InvalidLegacyPrefix,
+            BitcoinParseError::NetworkValidation(_) => AddressParseError::NetworkValidation,
+            _ => AddressParseError::OtherAddressParseErr,
+        }
+    }
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum FeeRateError {
     #[error("arithmetic overflow on feerate")]
     ArithmeticOverflow,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum FromScriptError {
+    #[error("script is not a p2pkh, p2sh or witness program")]
+    UnrecognizedScript,
+
+    #[error("witness program error: {error_message}")]
+    WitnessProgram { error_message: String },
+
+    #[error("witness version construction error: {error_message}")]
+    WitnessVersion { error_message: String },
+
+    // This error is required because the bitcoin::address::FromScriptError is non-exhaustive
+    #[error("other from script error")]
+    OtherFromScriptErr,
+}
+
+impl From<BitcoinFromScriptError> for FromScriptError {
+    fn from(error: BitcoinFromScriptError) -> Self {
+        match error {
+            BitcoinFromScriptError::UnrecognizedScript => FromScriptError::UnrecognizedScript,
+            BitcoinFromScriptError::WitnessProgram(e) => FromScriptError::WitnessProgram {
+                error_message: e.to_string(),
+            },
+            BitcoinFromScriptError::WitnessVersion(e) => FromScriptError::WitnessVersion {
+                error_message: e.to_string(),
+            },
+            _ => FromScriptError::OtherFromScriptErr,
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
Adding [Address](https://docs.rs/bitcoin/0.32.2/bitcoin/address/struct.Address.html) type.

**Note**
- I was able to use the macros but had to add `type CheckedBitcoinAddress = BitcoinAddress<NetworkChecked>;` since from what I can tell the macros are not designed to handle generic types like `BitcoinAddress<NetworkChecked>` (let me know if I'm mistaken though or if there's a better way)