### PR TITLE
chore: bump library version to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-ffi"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitcoin",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-ffi"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This crate does the light wrapping on [rust-bitcoin](https://github.com/rust-bit
 To leverage these types in your uniffi library, simply:
 1. Add a dependency on this crate:
 ```toml
-bitcoin-ffi = { git = "https://github.com/bitcoindevkit/bitcoin-ffi.git", tag = "v0.1.1" }
+bitcoin-ffi = { git = "https://github.com/bitcoindevkit/bitcoin-ffi.git", tag = "v0.1.2" }
 ```
 
 2. Add the following declarations to your UDL file for the types you wish to import. To read more about external type definitions, see [this page on the Uniffi documentation](https://mozilla.github.io/uniffi-rs/latest/udl/ext_types_external.html).


### PR DESCRIPTION
This PR bumps the library version to 0.1.2 so we can use it to release the beta 2 version of bdk-ffi while stress-testing the new types.