### PR TITLE
Add `Transaction`

### DIFF
--- a/src/bitcoin.udl
+++ b/src/bitcoin.udl
@@ -82,6 +82,23 @@ dictionary TxOut {
   Script script_pubkey;
 };
 
+interface Transaction {
+  [Name=deserialize, Throws=EncodeError]
+  constructor([ByRef] bytes transaction_bytes);
+  bytes serialize();
+  string compute_txid();
+  u64 total_size();
+  u64 vsize();
+  boolean is_coinbase();
+  boolean is_explicitly_rbf();
+  boolean is_lock_time_enabled();
+  i32 version();
+  u64 weight();
+  sequence<TxIn> input();
+  sequence<TxOut> output();
+  u32 lock_time();
+};
+
 // ------------------------------------------------------------------------
 // Errors
 // ------------------------------------------------------------------------
@@ -121,4 +138,15 @@ interface ParseAmountError {
 [Error]
 interface FeeRateError {
   ArithmeticOverflow();
+};
+
+[Error]
+interface EncodeError {
+  Io();
+  OversizedVectorAllocation();
+  InvalidChecksum(string expected, string actual);
+  NonMinimalVarInt();
+  ParseFailed();
+  UnsupportedSegwitFlag(u8 flag);
+  OtherEncodeErr();
 };


### PR DESCRIPTION
I used what was in `bdk-ffi` with some minor changes:
- Renamed the error to `EncodeError`, as it is the same error for other consensus encodings. In the future we may want to deserialize more types using this error.
- Renamed `serialize` to `consensus_serialize`
- Explicitly `clone` when generating the `Vec<TxIn>` and `Vec<TxOut>`
- Made the tuple struct public, as other library developers may want to work with the transaction directly

I really like what Davidson did with his PR, as he allowed users to construct a `Transaction` from `TxIn`, `TxOut`, `Version`, `LockTime`. However, I decided to leave that out because it requires more types and discussion (should we support non-standard versions). 