### PR TITLE
Add `From` trait for `&BitcoinTxIn`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,17 @@ impl From<BitcoinTxIn> for TxIn {
     }
 }
 
+impl From<&BitcoinTxIn> for TxIn {
+    fn from(tx_in: &BitcoinTxIn) -> Self {
+        TxIn {
+            previous_output: tx_in.previous_output,
+            script_sig: Arc::new(tx_in.script_sig.clone().into()),
+            sequence: tx_in.sequence.0,
+            witness: tx_in.witness.to_vec(),
+        }
+    }
+}
+
 impl From<TxIn> for BitcoinTxIn {
     fn from(value: TxIn) -> Self {
         Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,12 +178,12 @@ pub struct TxIn {
 }
 
 impl From<BitcoinTxIn> for TxIn {
-    fn from(value: BitcoinTxIn) -> Self {
-        Self {
-            previous_output: value.previous_output,
-            script_sig: Arc::new(value.script_sig.into()),
-            sequence: value.sequence.0,
-            witness: value.witness.to_vec(),
+    fn from(tx_in: BitcoinTxIn) -> Self {
+        TxIn {
+            previous_output: tx_in.previous_output,
+            script_sig: Arc::new(tx_in.script_sig.into()),
+            sequence: tx_in.sequence.0,
+            witness: tx_in.witness.to_vec(),
         }
     }
 }
@@ -200,12 +200,12 @@ impl From<&BitcoinTxIn> for TxIn {
 }
 
 impl From<TxIn> for BitcoinTxIn {
-    fn from(value: TxIn) -> Self {
-        Self {
-            previous_output: value.previous_output,
-            script_sig: value.script_sig.0.clone(),
-            sequence: Sequence(value.sequence),
-            witness: value.witness.into(),
+    fn from(tx_in: TxIn) -> Self {
+        BitcoinTxIn {
+            previous_output: tx_in.previous_output,
+            script_sig: tx_in.script_sig.0.clone(),
+            sequence: Sequence(tx_in.sequence),
+            witness: tx_in.witness.into(),
         }
     }
 }


### PR DESCRIPTION
This trait is required for [our use of the `TxIn` type](https://github.com/bitcoindevkit/bdk-ffi/blob/ed2aadf578dc295a7614853371ae639fd1be4801/bdk-ffi/src/bitcoin.rs#L125-L127).

I also:
- Made a small clean up commit to use what I think is easier to read variable names for the From trait
- Made the return type of the From trait explicit instead of using `Self` (my understanding is that it's more idiomatic that way).
