### PR TITLE
chore: uniffi 0.28.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ default = ["uniffi/cli"]
 
 [dependencies]
 bitcoin = { version = "0.32.2" }
-uniffi = { version = "=0.28.0" }
+uniffi = { version = "=0.28.2" }
 thiserror = "1.0.58"
 
 [build-dependencies]
-uniffi = { version = "=0.28.0", features = ["build"] }
+uniffi = { version = "=0.28.2", features = ["build"] }


### PR DESCRIPTION
Updating to uniffi https://github.com/mozilla/uniffi-rs/releases/tag/v0.28.2

Testing out some of https://mozilla.github.io/uniffi-rs/next/swift/uniffi-bindgen-swift.html

Which is only available in 0.28.2 https://github.com/mozilla/uniffi-rs/pull/2248#issue-2553034963