### PR TITLE
feat: add testnet4 to network type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "bitcoin_ffi"
 default = ["uniffi/cli"]
 
 [dependencies]
-bitcoin = { version = "0.32.2" }
+bitcoin = { version = "0.32.4" }
 uniffi = { version = "=0.28.2" }
 thiserror = "1.0.58"
 

--- a/src/bitcoin.udl
+++ b/src/bitcoin.udl
@@ -4,6 +4,7 @@ namespace bitcoin {};
 enum Network {
     "Bitcoin",
     "Testnet",
+    "Testnet4",
     "Signet",
-    "Regtest",
+    "Regtest"
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,6 +303,7 @@ pub enum Network {
     #[default]
     Bitcoin,
     Testnet,
+    Testnet4,
     Signet,
     Regtest,
 }
@@ -312,20 +313,9 @@ impl From<Network> for bitcoin::Network {
         match network {
             Network::Bitcoin => bitcoin::Network::Bitcoin,
             Network::Testnet => bitcoin::Network::Testnet,
+            Network::Testnet4 => bitcoin::Network::Testnet4,
             Network::Signet => bitcoin::Network::Signet,
             Network::Regtest => bitcoin::Network::Regtest,
-        }
-    }
-}
-
-impl From<bitcoin::Network> for Network {
-    fn from(network: bitcoin::Network) -> Self {
-        match network {
-            bitcoin::Network::Bitcoin => Network::Bitcoin,
-            bitcoin::Network::Testnet => Network::Testnet,
-            bitcoin::Network::Signet => Network::Signet,
-            bitcoin::Network::Regtest => Network::Regtest,
-            _ => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
### Description

Add `Testnet4` to `Network` type

### Notes to Reviewers

The first tag I see rust-bitcoin [Network](https://github.com/rust-bitcoin/rust-bitcoin/blob/bitcoin-0.32.4/bitcoin/src/network.rs) added `Testnet4` is 0.32.4 so I bumped our dependency version on `bitcoin`
