### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin-ffi"
-version = "0.1.2"
+version = "0.1.3"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 


### PR DESCRIPTION
This comment from @DanGould got me thinking about us doing a new release/version https://github.com/LtbLightning/payjoin-ffi/pull/43#issuecomment-2718330549 which I think makes sense

So this PR bumps version but is moreso a place to discuss if there is anything else we want to get in before we have a new release?
- I'd love to get #31 merged, but not a blocker
- possibly bump all the way to uniffi 0.29?
  - #33 

Would love any thoughts or suggestions from anyone else, while also not taking too long to get a new release out here for users like payjoin-ffi