### PR TITLE
chore: uniffi 0.29.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ default = ["uniffi/cli"]
 
 [dependencies]
 bitcoin = { version = "0.32.4" }
-uniffi = { version = "=0.28.2" }
+uniffi = { version = "=0.29.0" }
 thiserror = "1.0.58"
 
 [build-dependencies]
-uniffi = { version = "=0.28.2", features = ["build"] }
+uniffi = { version = "=0.29.0", features = ["build"] }

--- a/src/bitcoin.udl
+++ b/src/bitcoin.udl
@@ -1,6 +1,6 @@
 namespace bitcoin {};
 
-[NonExhaustive]
+[NonExhaustive, Remote]
 enum Network {
     "Bitcoin",
     "Testnet",

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -18,19 +18,16 @@ macro_rules! impl_from_ffi_type {
     };
 }
 
+#[macro_export]
 macro_rules! define_custom_string_type {
     ($ffi_type:ident) => {
-        uniffi::custom_type!($ffi_type, String);
-
-        impl UniffiCustomTypeConverter for $ffi_type {
-            type Builtin = String;
-            fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
-                Ok(val.parse::<$ffi_type>()?)
-            }
-
-            fn from_custom(obj: Self) -> Self::Builtin {
-                obj.to_string()
-            }
-        }
+        uniffi::custom_type!($ffi_type, String, {
+            remote,
+            lower: |value: $ffi_type| value.to_string(),
+            try_lift: |value: String| value.parse()
+                .map_err(|_| uniffi::deps::anyhow::Error::msg(
+                    format!("Failed to parse {} from string", stringify!($ffi_type))
+                )),
+        });
     };
 }

--- a/uniffi-bindgen/Cargo.toml
+++ b/uniffi-bindgen/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-uniffi = { version = "0.28.0", features = ["cli"] }
+uniffi = { version = "0.29.0", features = ["cli"] }


### PR DESCRIPTION
Updated to uniffi 0.29.0

- Updated to 0.29.0 in `Cargo.toml`s
- Added `remote` attribute and tried to update `define_custom_string_type` macro to match new [custom type](https://mozilla.github.io/uniffi-rs/next/Upgrading.html#custom-types) handling
