### PR TITLE
Uniffi 0.29.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ default = ["uniffi/cli"]
 
 [dependencies]
 bitcoin = { version = "0.32.4" }
-uniffi = { version = "=0.29.0" }
+uniffi = { version = "=0.29.1" }
 thiserror = "1.0.58"
 
 [build-dependencies]
-uniffi = { version = "=0.29.0", features = ["build"] }
+uniffi = { version = "=0.29.1", features = ["build"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ default = ["uniffi/cli"]
 
 [dependencies]
 bitcoin = { version = "0.32.4" }
-uniffi = { version = "=0.29.1" }
+uniffi = { version = "0.29.1" }
 thiserror = "1.0.58"
 
 [build-dependencies]
-uniffi = { version = "=0.29.1", features = ["build"] }
+uniffi = { version = "0.29.1", features = ["build"] }


### PR DESCRIPTION
0.29.1 [contains some bug fixes](https://github.com/mozilla/uniffi-rs/blob/main/CHANGELOG.md#v0291-backend-crates-v0291---2025-03-18) which appear necessary to embed bitcoin-ffi types in payjoin-ffi. I wasn't able to build on them with proc macros otherwise.

I've also removed the exact `=` Cargo.toml dependency version specification since that prevented this bug fix from being applied without this upstream change.