### PR TITLE
Export `Display` for Address

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod macros;
 pub mod error;
 
 #[derive(Debug, Clone, PartialEq, Eq, uniffi::Object)]
+#[uniffi::export(Display)]
 pub struct Address(bitcoin::Address<NetworkChecked>);
 
 #[uniffi::export]


### PR DESCRIPTION
`std::fmt::Display` impls are not exported automatically. Display is exported to the foreign language when decorated with `#[uniffi::export(Display)]`.

cc @benalleng